### PR TITLE
feat: generate code after chat completes

### DIFF
--- a/app/assistant.tsx
+++ b/app/assistant.tsx
@@ -67,10 +67,14 @@ export const Assistant = () => {
       lastProcessedAssistantId.current = last.id;
       isGeneratingRef.current = true;
       try {
+        const sanitized = payload.messages.map((m) => ({
+          ...m,
+          parts: m.parts?.filter((p) => p.type === "text"),
+        }));
         const response = await fetch("/api/generate-code", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ messages: payload.messages }),
+          body: JSON.stringify({ messages: sanitized }),
         });
         if (!response.ok || !response.body) throw new Error(`HTTP ${response.status}`);
 

--- a/components/ai/Chat.tsx
+++ b/components/ai/Chat.tsx
@@ -17,7 +17,11 @@ type ChatProps = {
 
 export function Chat({ className, onAssistantTurnEnd }: ChatProps) {
   const [input, setInput] = useState("");
-  const { messages, sendMessage, status } = useChat();
+  const { messages, sendMessage, status } = useChat({
+    onFinish() {
+      onAssistantTurnEnd?.({ messages });
+    },
+  });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- trigger code generation only after assistant message streaming completes
- send only text parts of messages to code generator

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b480c6aa148326bbf70bde91c28415