### PR TITLE
fix: stabilize chat scrolling

### DIFF
--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -12,8 +12,8 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>;
 export const Conversation = ({ className, ...props }: ConversationProps) => (
   <StickToBottom
     className={cn('relative flex-1 overflow-y-auto', className)}
-    initial="smooth"
-    resize="smooth"
+    initial="instant"
+    resize="instant"
     role="log"
     {...props}
   />

--- a/components/ai/Chat.tsx
+++ b/components/ai/Chat.tsx
@@ -2,12 +2,11 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { Conversation, ConversationContent, ConversationScrollButton } from "@/components/ai-elements/conversation";
+import { Conversation, ConversationContent } from "@/components/ai-elements/conversation";
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import { Response } from "@/components/ai-elements/response";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { PromptInput, PromptInputTextarea, PromptInputToolbar, PromptInputSubmit } from "@/components/ai-elements/prompt-input";
-import { Loader } from "@/components/ai-elements/loader";
 import { UIMessage, useChat } from "@ai-sdk/react";
 
 type ChatProps = {
@@ -80,9 +79,7 @@ export function Chat({ className, onAssistantTurnEnd }: ChatProps) {
               </Message>
             ))}
 
-            {status === "streaming" && <Loader />}
           </ConversationContent>
-          <ConversationScrollButton />
         </Conversation>
       </div>
 


### PR DESCRIPTION
## Summary
- remove scroll-to-bottom button and loader so chat streams output text only
- keep instant stick-to-bottom scrolling to avoid jitter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4e2f7964483269fded553144c85be