### PR TITLE
refactor loading screen and preview layout

### DIFF
--- a/components/loading-screen.tsx
+++ b/components/loading-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import StreamedCode, { StreamedCodeHandle } from "@/components/StreamedCode";
 import TetrisLoadingGame from "@/components/tetris-loading-game";
@@ -42,44 +42,40 @@ export default function LoadingScreen({ codeRef, bytes, lines, startedAt, onCanc
 
   return (
     <div className="flex h-full w-full flex-col p-4" aria-busy="true">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-2 pb-3">
-        <div className="flex items-center gap-2">
-          <div className="size-2 rounded-full bg-primary animate-pulse" aria-hidden />
-          <div className="text-sm font-medium">Generating Game HTML…</div>
-          <span className="sr-only" role="status" aria-live="polite">
-            Streaming game HTML. {formatBytes(bytes)} received, {lines} lines.
-          </span>
-        </div>
-        <div className="flex items-center gap-3 text-xs text-muted-foreground">
-          <div><span className="text-foreground font-medium">{formatBytes(bytes)}</span> streamed</div>
-          <div><span className="text-foreground font-medium">{lines}</span> lines</div>
-          <div><span className="text-foreground font-medium">{formatElapsed(elapsed)}</span> elapsed</div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button size="sm" variant="outline" onClick={() => setPaused(p => !p)}>
-            {paused ? <PlayIcon className="size-4" /> : <PauseIcon className="size-4" />}
-            <span className="ml-1 hidden sm:inline">{paused ? "Resume" : "Pause"} Tetris</span>
-          </Button>
-          <Button size="sm" variant="ghost" onClick={() => setShowStream(s => !s)}>
-            {showStream ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
-            <span className="ml-1 hidden sm:inline">{showStream ? "Hide" : "Show"} Stream</span>
-          </Button>
-          <Button size="sm" variant="destructive" onClick={onCancel}>
-            <XIcon className="size-4" />
-            <span className="ml-1 hidden sm:inline">Cancel</span>
-          </Button>
-        </div>
-      </div>
-
-      {/* Content */}
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 md:grid-cols-2">
         {/* Stream panel */}
         {showStream && (
           <div className="min-h-0 overflow-hidden rounded-lg border bg-card">
-            <div className="border-b px-3 py-2 text-xs text-muted-foreground">HTML Stream</div>
+            <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <div className="size-2 rounded-full bg-primary animate-pulse" aria-hidden />
+                <div className="font-medium">HTML Stream</div>
+              </div>
+              <span className="sr-only" role="status" aria-live="polite">
+                Streaming game HTML. {formatBytes(bytes)} received, {lines} lines.
+              </span>
+              <div className="flex items-center gap-3 text-muted-foreground">
+                <div><span className="text-foreground font-medium">{formatBytes(bytes)}</span> streamed</div>
+                <div><span className="text-foreground font-medium">{lines}</span> lines</div>
+                <div><span className="text-foreground font-medium">{formatElapsed(elapsed)}</span> elapsed</div>
+                <div className="flex items-center gap-2 pl-3">
+                  <Button size="sm" variant="outline" onClick={() => setPaused(p => !p)}>
+                    {paused ? <PlayIcon className="size-4" /> : <PauseIcon className="size-4" />}
+                    <span className="ml-1 hidden sm:inline">{paused ? "Resume" : "Pause"} Tetris</span>
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => setShowStream(s => !s)}>
+                    {showStream ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
+                    <span className="ml-1 hidden sm:inline">{showStream ? "Hide" : "Show"} Stream</span>
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={onCancel}>
+                    <XIcon className="size-4" />
+                    <span className="ml-1 hidden sm:inline">Cancel</span>
+                  </Button>
+                </div>
+              </div>
+            </div>
             <div className="min-h-0 h-full max-h-full">
-              <StreamedCode ref={codeRef as any} title="Generating Game Code..." language="markup" className="h-[60vh] md:h-full w-full" />
+              <StreamedCode ref={codeRef} title="Generating Game Code..." language="markup" className="h-[60vh] md:h-full w-full" />
             </div>
           </div>
         )}

--- a/components/tetris-loading-game.tsx
+++ b/components/tetris-loading-game.tsx
@@ -378,7 +378,7 @@ export default function TetrisLoadingGame({
       onBlur={() => setIsFocused(false)}
       onClick={(e) => { (e.currentTarget as HTMLDivElement).focus() }}
       style={{
-        // @ts-ignore CSS var helper
+        // @ts-expect-error CSS var helper
         "--cell-size": `${cellPx}px`,
       }}
     >


### PR DESCRIPTION
## Summary
- center game preview placeholder and simplify state handling
- merge loading stats and controls into stream header
- replace ts-ignore with ts-expect-error in Tetris loading game

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baf2104e048326903180bd4c7f8ca4